### PR TITLE
Fix timer freezing due to dead Blazor subscriptions killing game runners

### DIFF
--- a/OWLServer/OWLServer/Components/ConfigComponents/TowerConfig.razor.cs
+++ b/OWLServer/OWLServer/Components/ConfigComponents/TowerConfig.razor.cs
@@ -5,7 +5,7 @@ using Radzen.Blazor;
 
 namespace OWLServer.Components.ConfigComponents;
 
-public partial class TowerConfig : ComponentBase
+public partial class TowerConfig : ComponentBase, IDisposable
 {
     [Inject]
     public GameStateService GameStateService { get; set; } = null!;
@@ -25,11 +25,17 @@ public partial class TowerConfig : ComponentBase
         rdGrid.CancelEditRow(order);
     }
     
+    private Action _stateChangedHandler = null!;
+
     protected override void OnInitialized()
     {
-        ExternalTriggerService.StateHasChangedAction += () => InvokeAsync(StateHasChanged);
+        _stateChangedHandler = () => InvokeAsync(StateHasChanged);
+        ExternalTriggerService.StateHasChangedAction += _stateChangedHandler;
         base.OnInitialized();
     }
-    
-    
+
+    public void Dispose()
+    {
+        ExternalTriggerService.StateHasChangedAction -= _stateChangedHandler;
+    }
 }

--- a/OWLServer/OWLServer/Components/Pages/AdminPages/AdminPanel.razor.cs
+++ b/OWLServer/OWLServer/Components/Pages/AdminPages/AdminPanel.razor.cs
@@ -6,17 +6,25 @@ using Radzen;
 
 namespace OWLServer.Components.Pages.AdminPages;
 
-public partial class AdminPanel : ComponentBase
+public partial class AdminPanel : ComponentBase, IDisposable
 {
     [Inject]
     GameStateService GameStateService { get; set; } = null!;
     [Inject]
     ExternalTriggerService ExternalTriggerService { get; set; } = null!;
-    
+
+    private Action _stateChangedHandler = null!;
+
     protected override void OnInitialized()
     {
-        ExternalTriggerService.StateHasChangedAction += () => InvokeAsync(StateHasChanged);
+        _stateChangedHandler = () => InvokeAsync(StateHasChanged);
+        ExternalTriggerService.StateHasChangedAction += _stateChangedHandler;
         base.OnInitialized();
+    }
+
+    public void Dispose()
+    {
+        ExternalTriggerService.StateHasChangedAction -= _stateChangedHandler;
     }
     private void GameModeChanged(GameMode? mode)
     {

--- a/OWLServer/OWLServer/Components/Pages/AdminPages/AdminStartPage.razor.cs
+++ b/OWLServer/OWLServer/Components/Pages/AdminPages/AdminStartPage.razor.cs
@@ -2,13 +2,19 @@ using Microsoft.AspNetCore.Components;
 
 namespace OWLServer.Components.Pages.AdminPages;
 
-public partial class AdminStartPage : ComponentBase
+public partial class AdminStartPage : ComponentBase, IDisposable
 {
-    
-    
+    private Action _stateChangedHandler = null!;
+
     protected override void OnInitialized()
     {
-        ExternalTriggerService.StateHasChangedAction += () => InvokeAsync(StateHasChanged);
+        _stateChangedHandler = () => InvokeAsync(StateHasChanged);
+        ExternalTriggerService.StateHasChangedAction += _stateChangedHandler;
         base.OnInitialized();
+    }
+
+    public void Dispose()
+    {
+        ExternalTriggerService.StateHasChangedAction -= _stateChangedHandler;
     }
 }

--- a/OWLServer/OWLServer/Components/TeamPanel/MatchScoreBar.razor.cs
+++ b/OWLServer/OWLServer/Components/TeamPanel/MatchScoreBar.razor.cs
@@ -8,7 +8,7 @@ using System.Drawing;
 
 namespace OWLServer.Components.TeamPanel;
 
-public partial class MatchScoreBar : ComponentBase
+public partial class MatchScoreBar : ComponentBase, IDisposable
 {
     [Inject]
     private GameStateService _gameStateService { get; set; } = null!;
@@ -32,6 +32,11 @@ public partial class MatchScoreBar : ComponentBase
             _triggerService.StateHasChangedAction += StateHasChangedAction;
             StateHasChangedAction();
         }
+    }
+
+    public void Dispose()
+    {
+        _triggerService.StateHasChangedAction -= StateHasChangedAction;
     }
 
     private void StateHasChangedAction()

--- a/OWLServer/OWLServer/Models/GameModes/GameModeConquest.cs
+++ b/OWLServer/OWLServer/Models/GameModes/GameModeConquest.cs
@@ -111,7 +111,8 @@ public class GameModeConquest : IGameModeBase, IDisposable
                 break;
             }
             
-            ExternalTriggerService.StateHasChangedAction.Invoke();
+            try { ExternalTriggerService.StateHasChangedAction?.Invoke(); }
+            catch { }
         }
     }
 

--- a/OWLServer/OWLServer/Models/GameModes/GameModeTeamDeathmatch.cs
+++ b/OWLServer/OWLServer/Models/GameModes/GameModeTeamDeathmatch.cs
@@ -29,7 +29,8 @@ public class GameModeTeamDeathmatch : IGameModeBase, IDisposable
         if (StartTime != null && IsRunning)
         {
             TeamDeaths[args.TeamColor] += 1;
-            ExternalTriggerService.StateHasChangedAction.Invoke();
+            try { ExternalTriggerService.StateHasChangedAction?.Invoke(); }
+            catch { }
         }
     }
 
@@ -101,7 +102,8 @@ public class GameModeTeamDeathmatch : IGameModeBase, IDisposable
                 break;
             }
             
-            ExternalTriggerService.StateHasChangedAction?.Invoke();
+            try { ExternalTriggerService.StateHasChangedAction?.Invoke(); }
+            catch { }
         }
     }
 

--- a/OWLServer/OWLServer/Models/GameModes/GameModeTimer.cs
+++ b/OWLServer/OWLServer/Models/GameModes/GameModeTimer.cs
@@ -45,7 +45,8 @@ public class GameModeTimer : IGameModeBase
                 break;
             }
             
-            ExternalTriggerService.StateHasChangedAction?.Invoke();
+            try { ExternalTriggerService.StateHasChangedAction?.Invoke(); }
+            catch { }
         }
     }
 


### PR DESCRIPTION
Components never unsubscribed from ExternalTriggerService.StateHasChangedAction, leaving disposed circuit delegates in the multicast chain. When a runner invoked the chain and hit a dead component, the exception propagated uncaught through the Runner() loop, permanently terminating the background task and freezing the timer.

- Implement IDisposable on MatchScoreBar, AdminPanel, AdminStartPage, TowerConfig to unsubscribe on component disposal (store lambdas in fields for -=)
- Wrap StateHasChangedAction.Invoke() in try/catch in all three game mode runners so a single bad subscriber can never kill the update loop
- Fix bare .Invoke() (no null-check) in GameModeConquest and GameModeTeamDeathmatch